### PR TITLE
KEP-725 - Empty value protobuf update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ matrix:
             - ubuntu-toolchain-r-test
             - sourceline: 'deb http://ppa.launchpad.net/maarten-fonville/protobuf/ubuntu trusty main'
               key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x4DEA8909DC6A13A3'
-    - os: osx
-      env: "emulatorIntegration=true"
 
 language: node_js
 node_js:
@@ -30,13 +28,9 @@ node_js:
 before_install:
 - npm version "$PROJECT_VERSION"
 - "./travis_install.sh"
-- if [ "$emulatorIntegration" = "true" ] ; then brew update; brew unlink python; brew
-  install protobuf; fi
+
 before_script:
 - webpack
-
-before_deploy:
-- if [ "$emulatorIntegration" = "true" ] ; then npm uninstall swarmemulator; fi
 
 deploy:
   skip_cleanup: true

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test-node": "port=8100 address=localhost emulatorQuiet=true mocha test/*.js --exit --timeout 5000",
     "setup-daemon": "cp -R ./test-daemon/configs/. ./test-daemon/daemon-build/output/",
     "test-daemon": "npm run setup-daemon; daemonIntegration=true port=50000 address=localhost emulatorQuiet=true mocha test/*.js --exit --timeout 8000",
-    "test": "if [ \"$daemonIntegration\" = true ] ; then npm run test-daemon; else npm run test-node; fi"
+    "test": "if [ \"$daemonIntegration\" = true ] ; then npm run test-daemon; else npm run test-node; fi",
+    "build": "webpack"
   },
   "devDependencies": {
     "async-wait-until": "^1.2.4",

--- a/src/api.js
+++ b/src/api.js
@@ -46,7 +46,7 @@ const onMessage = (client, bin) => {
 
 
     client.logger && 
-        setTimeout(() => client.logger("\nRecieving\n",response_json), 0);
+        setTimeout(() => client.logger("Receiving",response_json), 0);
 
 
 
@@ -140,7 +140,7 @@ const send = (client, database_msg, socket) =>
 
 
     client.logger && 
-        setTimeout(() => client.logger("\nSending\n", database_msg.toObject()), 0);
+        setTimeout(() => client.logger("Sending", database_msg.toObject()), 0);
 
 
     let serializedMessage;

--- a/src/api.js
+++ b/src/api.js
@@ -46,7 +46,7 @@ const onMessage = (client, bin) => {
 
 
     client.logger && 
-        setTimeout(() => client.logger("Receiving",response_json), 0);
+        setTimeout(() => client.logger("Receiving", response_json), 0);
 
 
 
@@ -109,7 +109,7 @@ const resolve = (response_json, response, o) => {
 
     if(response_json && response_json.read) {
 
-        response_json.read.value = response.getRead().getValue();
+        response_json.read.value = response.getRead().getValue_asU8();
 
     }
 
@@ -117,7 +117,15 @@ const resolve = (response_json, response, o) => {
     if(response_json && response_json.subscriptionUpdate) {
 
         response_json.subscriptionUpdate.value = 
-            response.getSubscriptionUpdate().getValue();
+            response.getSubscriptionUpdate().getValue_asU8();
+
+
+        // Set the value to undefined if it has been deleted.
+        // This propagates through the deserialization and remains undefined to the user.
+
+        if(response.getSubscriptionUpdate().getOperation() === proto.database_subscription_update.operation_type.DELETE) {
+            response_json.subscriptionUpdate.value = undefined;
+        }
 
     }
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -151,6 +151,7 @@ describe('bluzelle api', () => {
     it('should be able to create and read values that are empty strings', async () => {
 
         await api.create('emptykey', '');
+
         assert(await api.read('emptykey') === '');
 
     });

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -148,6 +148,12 @@ describe('bluzelle api', () => {
 
     });
 
+    it('should be able to create and read values that are empty strings', async () => {
+
+        await api.create('emptykey', '');
+        assert(await api.read('emptykey') === '');
+
+    });
 
     it('should be able to get a list of keys', async () => {
 

--- a/travis_install.sh
+++ b/travis_install.sh
@@ -2,33 +2,15 @@
 
 set -ev
 
-if [ "$daemonIntegration" = true ]; then
 
-  sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  sudo apt-get update
-  sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-unauthenticated --allow-downgrades --allow-remove-essential --allow-change-held-packages install g++-7 pkg-config protobuf-compiler libprotobuf-dev
-  sudo apt-get install --no-install-recommends ca-certificates --allow-unauthenticated bluzelle-swarmdb
-
-
-  cd test-daemon
-  mkdir -p daemon-build/output
-  cd daemon-build/output
-  ln -s `which swarm`
-  cd ../..
-
-else
-
-  # Add SSH Deploy key for swarmemulator
-
-  echo -e "Host *\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
-  echo -e "$SWARMEMULATOR_DEPLOY_KEY" > ~/.ssh/id_rsa
-  chmod 600 ~/.ssh/id_rsa
-  eval `ssh-agent -s`
-  ssh-add ~/.ssh/id_rsa
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+sudo apt-get update
+sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-unauthenticated --allow-downgrades --allow-remove-essential --allow-change-held-packages install g++-7 pkg-config protobuf-compiler libprotobuf-dev
+sudo apt-get install --no-install-recommends ca-certificates --allow-unauthenticated bluzelle-swarmdb
 
 
-  # Get the swarmemulator
-
-  npm install ssh://git@github.com/bluzelle/swarmemulator.git#task/mthibault/KEP-484
-
-fi
+cd test-daemon
+mkdir -p daemon-build/output
+cd daemon-build/output
+ln -s `which swarm`
+cd ../..

--- a/yarn.lock
+++ b/yarn.lock
@@ -2029,8 +2029,8 @@ globby@^8.0.0, globby@^8.0.1:
     slash "^1.0.0"
 
 google-protobuf@^3.5.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.6.0.tgz#e2bafb00c20a8734174d8f89e0a842709e2ceed0"
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.6.1.tgz#7ef58e2bea137a93cdaf5cfd5afa5f6abdd92025"
 
 got@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
Prior to this fix, it would not be possible to resolve a create command for a key with an empty value. This is because there was ambiguity to whether the response message from the daemon was representing a deleted value or an updated value to the empty case. 

This PR
- Adds a test for empty values
- Updates the proto configuration to https://github.com/bluzelle/swarmDB/pull/150 (KEP-733).