### PR TITLE
KEP-1248 - Added quickread response type

### DIFF
--- a/src/1_connection_layer.js
+++ b/src/1_connection_layer.js
@@ -336,10 +336,13 @@ const logIncoming = (bin, log) => {
         stuff.bzn.timestamp = bzn_stuff.timestamp;
 
 
+        log('Incoming database_response\n', stuff);
+
         // Make sure errors don't mess up this thread
-        setTimeout(() => 
-            log('Incoming database_response\n', stuff),
-            0);
+        
+        // setTimeout(() => 
+        //     log('Incoming database_response\n', stuff),
+        //     0);
 
     }
 

--- a/src/1_connection_layer.js
+++ b/src/1_connection_layer.js
@@ -336,13 +336,11 @@ const logIncoming = (bin, log) => {
         stuff.bzn.timestamp = bzn_stuff.timestamp;
 
 
-        log('Incoming database_response\n', stuff);
-
         // Make sure errors don't mess up this thread
         
-        // setTimeout(() => 
-        //     log('Incoming database_response\n', stuff),
-        //     0);
+        setTimeout(() => 
+            log('Incoming database_response\n', stuff),
+            0);
 
     }
 

--- a/src/9_api_layer.js
+++ b/src/9_api_layer.js
@@ -182,20 +182,23 @@ module.exports = class API {
 
             this.sendOutgoingMsg(msg, incoming_msg => {
 
-                if(incoming_msg.hasError()) {
+                assert(incoming_msg.hasQuickRead(),
+                    "A response other quickread has been returned from daemon for quickread.");
 
-                    reject(new Error(incoming_msg.getError().getMessage()));
-                    return true;
+
+                if(incoming_msg.getQuickRead().getError() === '') {
+
+                    assert(incoming_msg.getQuickRead().getKey() === key,
+                        "Key in response does not match key in request for read.");
+
+                    resolve(decode(incoming_msg.getQuickRead().getValue()));
+
+                } else {
+
+                    reject(new Error(incoming_msg.getQuickRead().getError()));
 
                 }
 
-                assert(incoming_msg.hasQuickRead(),
-                    "A response other than error or read has been returned from daemon for quickread.");
-
-                assert(incoming_msg.getQuickRead().getKey() === key,
-                    "Key in response does not match key in request for read.");
-
-                resolve(decode(incoming_msg.getQuickRead().getValue()));
 
                 return true;
 

--- a/src/test-integration/main.test.js
+++ b/src/test-integration/main.test.js
@@ -39,9 +39,14 @@ describe('integration', () => {
 
     it('create and read', async () => {
 
+        await assert.rejects(bz.quickread('blah'));
+        await assert.rejects(bz.read('blah'));
+
         await bz.createDB();
 
         await bz.create('hello', 'world');
+
+        await assert.rejects(bz.create('hello', 'whence'));
 
         assert.equal(await bz.read('hello'), 'world');
 
@@ -50,9 +55,12 @@ describe('integration', () => {
     });
 
 
+
     it('update', async () => {
 
         await bz.createDB();
+
+        await assert.rejects(bz.update('hello', 'whence'));
 
         await bz.create('hello', 'world');
 
@@ -81,6 +89,8 @@ describe('integration', () => {
 
         await bz.createDB();
 
+        await assert.rejects(bz.delete('hello'));
+
         await bz.create('hello', 'world');
 
         await bz.delete('hello');
@@ -105,6 +115,8 @@ describe('integration', () => {
 
     it('keys', async () => {    
 
+        await assert.rejects(bz.keys());
+
         await bz.createDB();
 
         assert.deepEqual(await bz.keys(), []);
@@ -118,9 +130,13 @@ describe('integration', () => {
 
     it('hasDB/createDB/deleteDB', async () => {    
 
+        await assert.rejects(bz.deleteDB());
+
         assert(!await bz.hasDB());
 
         await bz.createDB();
+
+        await assert.rejects(bz.createDB());
 
         assert(await bz.hasDB());
 


### PR DESCRIPTION
- The crypto module of bluzelle-js has no way of differentiating errors that should be verified from errors that should be unverified.
- This fix embeds quickread-related errors inside the quickread message.
- Added tests for API rejections.