### PR TITLE
KEP-1201

### DIFF
--- a/src/9_api_layer.js
+++ b/src/9_api_layer.js
@@ -342,7 +342,11 @@ module.exports = class API {
                 assert(incoming_msg.hasSize(),
                     "A response other than size has been returned from daemon for size.");
 
-                resolve(incoming_msg.getSize().getBytes());
+                resolve({
+                    bytes: incoming_msg.getSize().getBytes(),
+                    keys: incoming_msg.getSize().getKeys(),
+                    remainingBytes: incoming_msg.getSize().getRemainingBytes(),
+                });
 
                 return true;
 

--- a/src/9_api_layer.js
+++ b/src/9_api_layer.js
@@ -619,4 +619,120 @@ module.exports = class API {
 
     }
 
+
+    _getWriters() {
+
+        return new Promise((resolve, reject) => {
+
+            const msg = new database_pb.database_msg();
+
+            const req = new database_pb.database_request();
+            msg.setWriters(req);
+
+
+            this.sendOutgoingMsg(msg, incoming_msg => {
+
+                if(incoming_msg.hasError()) {
+
+                    reject(new Error(incoming_msg.getError().getMessage()));
+                    return true;
+
+                }
+
+                assert(incoming_msg.hasWriters(),
+                    "A response other than writers has been returned from daemon for writers.");
+
+                const resp = incoming_msg.getWriters();
+
+                resolve({
+                    owner: resp.getOwner(),
+                    writers: resp.getWritersList()
+                });
+
+                return true;
+
+            });
+
+        });
+
+    }
+
+
+    _addWriters(writers) {
+
+        assert(typeof writers === 'string' || (Array.isArray(writers) && writers.every(writer => typeof writer === 'string')),
+            'Writers must be a string or an array of strings');
+
+        return new Promise((resolve, reject) => {
+
+            const msg = new database_pb.database_msg();
+
+            const writers_msg = new database_pb.database_writers();
+            writers_msg.setWritersList(Array.isArray(writers) ? writers : [writers]);
+
+            msg.setAddWriters(writers_msg);
+
+
+            this.sendOutgoingMsg(msg, incoming_msg => {
+
+                if(incoming_msg.hasError()) {
+
+                    reject(new Error(incoming_msg.getError().getMessage()));
+                    return true;
+
+                }
+
+                assert(incoming_msg.getResponseCase() === 0,
+                    "A response other than error or ack has been returned from daemon for addWriters.");
+
+                resolve();
+
+                return true;
+
+            });
+
+        });
+
+    }
+
+
+    _deleteWriters(writers) {
+
+        assert(typeof writers === 'string' || (Array.isArray(writers) && writers.every(writer => typeof writer === 'string')),
+            'Writers must be a string or an array of strings');
+
+        return new Promise((resolve, reject) => {
+
+            const msg = new database_pb.database_msg();
+
+
+            const writers_msg = new database_pb.database_writers();
+            writers_msg.setWritersList(Array.isArray(writers) ? writers : [writers]);
+
+            msg.setRemoveWriters(writers_msg);
+
+
+            this.sendOutgoingMsg(msg, incoming_msg => {
+
+                if(incoming_msg.hasError()) {
+
+                    reject(new Error(incoming_msg.getError().getMessage()));
+                    return true;
+
+                }
+
+                assert(incoming_msg.getResponseCase() === 0,
+                    "A response other than error or ack has been returned from daemon for removeWriters.");
+
+                resolve();
+
+                return true;
+
+            });
+
+        });
+
+    }
+
+
 };

--- a/src/main.js
+++ b/src/main.js
@@ -30,7 +30,7 @@ const status_pb = require('../proto/status_pb');
 
 
 module.exports = {
-    bluzelle: ({entry, private_pem, log, p2p_latency_bound, onclose}) => {
+    bluzelle: ({entry, private_pem, uuid, log, p2p_latency_bound, onclose}) => {
 
         p2p_latency_bound = p2p_latency_bound || 100;
 
@@ -52,7 +52,7 @@ module.exports = {
             new Broadcast({ p2p_latency_bound, connection_layer, log, }),
             new Redirect({}),
             new Envelope({}),
-            new Metadata({ uuid: pub_key, log, }),
+            new Metadata({ uuid: uuid || pub_key, log, }),
         ];
 
         const sandwich = connect_layers(layers);

--- a/src/test-integration/main.test.js
+++ b/src/test-integration/main.test.js
@@ -104,11 +104,18 @@ describe('integration', () => {
 
         await bz.createDB();
 
-        assert.equal(await bz.size(), 0);
+        assert.deepEqual(await bz.size(), {
+            bytes: 0,
+            keys: 0,
+            remainingBytes: 0
+        });
 
         await bz.create('this', 'that');
 
-        assert(await bz.size() > 0);
+        const sz = await bz.size();
+        assert(sz.bytes > 0);
+        assert(sz.keys === 1);
+        assert(sz.remainingBytes === 0);
 
     });
 


### PR DESCRIPTION
(On top of KEP-1260)

- Updated size() to return an object that has `bytes`, `keys`, and `remainingBytes` as fields. Previously it returned `bytes` as an integer.
- More testing needs to be done to ensure that `remainingBytes` is compliant with the actual state of the database.