### PR TITLE
KEP-1372

### DIFF
--- a/scripts/deploy-ethereum.js
+++ b/scripts/deploy-ethereum.js
@@ -19,17 +19,15 @@ const rndString = () => new Array(10).fill(0).map(() => Math.floor(Math.random()
 
 const addSwarm = async (json, BluzelleESRInstance) => {
 
-    const swarm_id = "12345";
+    await BluzelleESRInstance.addSwarm(json.swarm_id,7,"Canada",true,"Disk",0,[],{ from: myAccount });
 
-    await BluzelleESRInstance.addSwarm(swarm_id,7,"Canada",true,"Disk",0,[],{ from: myAccount });
-
-    for(var i=0; i<json.length; i++){
-        await BluzelleESRInstance.addNode(swarm_id,
-            json[i].host,
-            json[i].name,
-            json[i].http_port,
-            json[i].port,
-            json[i].uuid
+    for(var i=0; i<json.peers.length; i++){
+        await BluzelleESRInstance.addNode(json.swarm_id,
+            json.peers[i].host,
+            json.peers[i].name,
+            json.peers[i].http_port,
+            json.peers[i].port,
+            json.peers[i].uuid
             );
     }
 
@@ -60,7 +58,7 @@ const main = async () => {
     recordTransaction("BluzelleESR.new", receiptTx, true);
 
 
-    const ps = fs.readdirSync('../swarmDB/local/nodes').filter(s => /^peers.*\.json$/.exec(s)).map(async file => {
+    const ps = fs.readdirSync('../swarmDB/local/nodes').filter(s => /^swarm.*\.json$/.exec(s)).map(async file => {
 
         const f = '../swarmDB/local/nodes/' + file;
         const json = JSON.parse(fs.readFileSync(f, 'utf8'));

--- a/scripts/run-swarms.rb
+++ b/scripts/run-swarms.rb
@@ -42,8 +42,11 @@ i = 0
 (0...ARGV.length).each do |n|
 
   peers_file = base_dir + "/swarmDB/local/nodes/peers#{n}.json"
+  swarm_file = base_dir + "/swarmDB/local/nodes/swarm#{n}.json"
 
   peers = []
+
+  swarm_id = 'swarm' + n.to_s
 
   (0...ARGV[n].to_i).each do 
 
@@ -86,7 +89,7 @@ i = 0
       "monitor_address": "localhost",
       "monitor_port": 8125,
       "ws_idle_timeout": 10000,
-      "swarm_id": 12345
+      "swarm_id": "#{swarm_id}"
       }))
 
 
@@ -95,8 +98,14 @@ i = 0
     i += 1
   end
 
-  File.write(peers_file, '[' + peers.join(",\n") + ']')
 
+  peers_json = '[' + peers.join(",\n") + ']'
+
+  File.write(peers_file, peers_json)
+
+  swarm_json = %({"swarm_id":"#{swarm_id}","peers":#{peers_json}})
+
+  File.write(swarm_file, swarm_json)
 
 end
 


### PR DESCRIPTION
- Added dynamic swarmID to the run-swarms script (defaulting to swarm0, swarm1, etc.)
- The ethereum publishing script used to be based solely off the peers list. Now it uses an augmented peers list (swarm[n].json) that includes the peers and the swarm_id.