### PR TITLE
KEP-1375 - Improved bluzelle-js logging

### DIFF
--- a/src/swarmClient/log.js
+++ b/src/swarmClient/log.js
@@ -1,0 +1,80 @@
+// Copyright (C) 2019 Bluzelle
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License, version 3,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+
+
+// Reset = "\x1b[0m"
+// Bright = "\x1b[1m"
+// Dim = "\x1b[2m"
+// Underscore = "\x1b[4m"
+// Blink = "\x1b[5m"
+// Reverse = "\x1b[7m"
+// Hidden = "\x1b[8m"
+
+// FgBlack = "\x1b[30m"
+// FgRed = "\x1b[31m"
+// FgGreen = "\x1b[32m"
+// FgYellow = "\x1b[33m"
+// FgBlue = "\x1b[34m"
+// FgMagenta = "\x1b[35m"
+// FgCyan = "\x1b[36m"
+// FgWhite = "\x1b[37m"
+
+// BgBlack = "\x1b[40m"
+// BgRed = "\x1b[41m"
+// BgGreen = "\x1b[42m"
+// BgYellow = "\x1b[43m"
+// BgBlue = "\x1b[44m"
+// BgMagenta = "\x1b[45m"
+// BgCyan = "\x1b[46m"
+// BgWhite = "\x1b[47m"
+
+
+const reset = "\x1b[0m";
+
+const underscore = "\x1b[4m";
+
+const bgBlack = "\x1b[40m";
+
+const colors = {
+    //black: "\x1b[30m",
+    red: "\x1b[31m",
+    green: "\x1b[32m",
+    yellow: "\x1b[33m",
+    blue: "\x1b[34m",
+    magenta: "\x1b[35m",
+    cyan: "\x1b[36m",
+    //white: "\x1b[37m"
+};
+
+
+
+const coloredString = str => {
+
+    const n = str.split('').map(c => c.charCodeAt(0)).reduce((a, b) => a + b);
+
+    const i = n % Object.values(colors).length;
+
+    return Object.values(colors)[i] + str + reset;
+
+};
+
+const coloredNonce = nonce => coloredString(nonce.padStart(20, '0'));
+
+
+module.exports = {
+    coloredString,
+    coloredNonce,
+};

--- a/src/test/main.test.js
+++ b/src/test/main.test.js
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Bluzelle
+ // Copyright (C) 2019 Bluzelle
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License, version 3,
@@ -32,9 +32,10 @@ assert.rejects = assert.rejects || (async (p, e) => {
 
 
 const ethereum_rpc = 'http://127.0.0.1:8545';
-const contract_address = '0x91d7efF59C0053c3648DF8d1B332F4348DD7b094';
+const contract_address = '0x8d22b2E44b31882ADa115889c964F593c41961dc';
 
-const log = false;
+const log = true;
+const logDetailed = false;
 
 
 // these mirror the keys in scripts/run-swarms.rb
@@ -56,6 +57,7 @@ describe('Secret master key database creation', () => {
 
             uuid: Math.random().toString(),
             log,
+            logDetailed,
 
             _connect_to_all: true
         });
@@ -76,6 +78,7 @@ describe('Secret master key database creation', () => {
 
             uuid: Math.random().toString(),
             log,
+            logDetailed,
 
             _connect_to_all: true
         });
@@ -112,6 +115,7 @@ it('rejects operations on a non-extant database', async () => {
 
         uuid: Math.random().toString(),
         log,
+        logDetailed,
     }), {
         message: "UUID does not exist in the Bluzelle swarm. Contact us at https://gitter.im/bluzelle/Lobby."
     });
@@ -137,6 +141,7 @@ describe('api', function() {
 
             uuid,
             log,
+            logDetailed,
 
             _connect_to_all: true
         });
@@ -156,6 +161,7 @@ describe('api', function() {
 
             uuid,
             log,
+            logDetailed,
         });
 
     });
@@ -387,6 +393,7 @@ describe('api', function() {
 
             uuid,
             log,
+            logDetailed,
         });
 
         bz2.close();
@@ -401,6 +408,7 @@ describe('api', function() {
 
             uuid,
             log,
+            logDetailed,
         }));
 
     });

--- a/src/test/main.test.js
+++ b/src/test/main.test.js
@@ -32,7 +32,7 @@ assert.rejects = assert.rejects || (async (p, e) => {
 
 
 const ethereum_rpc = 'http://127.0.0.1:8545';
-const contract_address = '0x6Cb639637166304A4D8969D05e47a4c36A334c9D';
+const contract_address = '0x91d7efF59C0053c3648DF8d1B332F4348DD7b094';
 
 const log = false;
 
@@ -269,13 +269,13 @@ describe('api', function() {
 
         assert(await bz.ttl('1') > 0);
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await new Promise(resolve => setTimeout(resolve, 2000));
 
         await assert.rejects(bz.read('1'));
 
     });
 
-    it('ttl with expire', async () => {
+    it('ttl with expire & persist', async () => {
         
         await bz.create('3', '4');
 
@@ -287,7 +287,20 @@ describe('api', function() {
 
         assert(await bz.ttl('3') > 0);
 
+        await bz.persist('3');
+
+        await assert.rejects(bz.ttl('3'));
+
     });
+
+
+    it('changing expiry', async () => {
+
+        await bz.create('4', '5', 6)
+        await bz.expire('4', 10)
+
+    });
+
 
     it('status', async () => {
 


### PR DESCRIPTION
- ANSI-colors in logging output (tested on Mac but should be multi-platform)
- New option, logDetailed, when set to true, prints out the full message contents. Log now prints only message summaries.
- Timestamp appended to each message

<img width="626" alt="Screen Shot 2019-05-14 at 9 33 19 AM" src="https://user-images.githubusercontent.com/1238401/57715338-5ef07900-762b-11e9-9915-a17f5475a66d.png">

