### PR TITLE
KEP-1511 - Configurable Timeouts

### DIFF
--- a/src/swarmClient/9_api_layer.js
+++ b/src/swarmClient/9_api_layer.js
@@ -24,6 +24,35 @@ const encode = string => new Uint8Array(Buffer.from(string, 'utf-8'));
 const decode = binary => Buffer.from(binary).toString('utf-8');
 
 
+
+// returns a normal promise with a default timeout
+
+// and a method .timeout(t) that can customize the time
+
+// when t=0, the timeout is indefinite 
+
+const timeout_promise = f => {
+
+    const default_timeout = 5000;
+
+    const timeout = t => 
+        Promise.race([
+            p, 
+            new Promise((_, rej) => setTimeout(() => rej(new Error('operation timed out after ' + t + 'ms')), t))
+        ]);
+
+
+    const p = new Promise(f);
+
+    const p2 = timeout(default_timeout);
+        
+    p2.timeout = t => t === 0 ? p : timeout(t);
+
+    return p2;
+
+};
+
+
 module.exports = class API {
 
     constructor(sendOutgoingMsg) {
@@ -35,7 +64,7 @@ module.exports = class API {
 
     status() {
 
-        return new Promise((resolve, reject) => {
+        return timeout_promise((resolve, reject) => {
 
             const status_request = new status_pb.status_request();
 
@@ -55,7 +84,7 @@ module.exports = class API {
         assert(typeof key === 'string', 'Key must be a string');
         assert(typeof value === 'string', 'Value must be a string');
 
-        return new Promise((resolve, reject) => {
+        return timeout_promise((resolve, reject) => {
 
             const msg = new database_pb.database_msg();
 
@@ -95,7 +124,7 @@ module.exports = class API {
         assert(typeof key === 'string', 'Key must be a string');
         assert(typeof value === 'string', 'Value must be a string');
 
-        return new Promise((resolve, reject) => {
+        return timeout_promise((resolve, reject) => {
 
             const msg = new database_pb.database_msg();
 
@@ -134,7 +163,7 @@ module.exports = class API {
 
         assert(typeof key === 'string', 'Key must be a string');
 
-        return new Promise((resolve, reject) => {
+        return timeout_promise((resolve, reject) => {
 
             const msg = new database_pb.database_msg();
 
@@ -173,7 +202,7 @@ module.exports = class API {
 
         assert(typeof key === 'string', 'Key must be a string');
 
-        return new Promise((resolve, reject) => {
+        return timeout_promise((resolve, reject) => {
 
             const msg = new database_pb.database_msg();
 
@@ -215,7 +244,7 @@ module.exports = class API {
 
         assert(typeof key === 'string', 'Key must be a string');
 
-        return new Promise((resolve, reject) => {
+        return timeout_promise((resolve, reject) => {
 
             const msg = new database_pb.database_msg();
 
@@ -252,7 +281,7 @@ module.exports = class API {
 
         assert(typeof key === 'string', 'Key must be a string');
 
-        return new Promise((resolve, reject) => {
+        return timeout_promise((resolve, reject) => {
 
             const msg = new database_pb.database_msg();
 
@@ -290,7 +319,7 @@ module.exports = class API {
 
     keys() {
 
-        return new Promise((resolve, reject) => {
+        return timeout_promise((resolve, reject) => {
 
             const msg = new database_pb.database_msg();
 
@@ -323,7 +352,7 @@ module.exports = class API {
 
     size() {
 
-        return new Promise((resolve, reject) => {
+        return timeout_promise((resolve, reject) => {
 
             const msg = new database_pb.database_msg();
 
@@ -363,7 +392,7 @@ module.exports = class API {
         assert(typeof key === 'string', 'Key must be a string');
         assert(typeof expire === 'number', 'Expiry must be a number');
 
-        return new Promise((resolve, reject) => {
+        return timeout_promise((resolve, reject) => {
 
             const msg = new database_pb.database_msg();
 
@@ -401,7 +430,7 @@ module.exports = class API {
 
         assert(typeof key === 'string', 'Key must be a string');
 
-        return new Promise((resolve, reject) => {
+        return timeout_promise((resolve, reject) => {
 
             const msg = new database_pb.database_msg();
 
@@ -438,7 +467,7 @@ module.exports = class API {
 
         assert(typeof key === 'string', 'Key must be a string');
 
-        return new Promise((resolve, reject) => {
+        return timeout_promise((resolve, reject) => {
 
             const msg = new database_pb.database_msg();
 
@@ -475,7 +504,7 @@ module.exports = class API {
 
     createDB(maxsize=0, policy_type='none') {
 
-        return new Promise((resolve, reject) => {
+        return timeout_promise((resolve, reject) => {
 
             const msg = new database_pb.database_msg();
 
@@ -517,7 +546,7 @@ module.exports = class API {
 
     updateDB(maxsize=0, policy_type='none') {
 
-        return new Promise((resolve, reject) => {
+        return timeout_promise((resolve, reject) => {
 
             const msg = new database_pb.database_msg();
 
@@ -559,7 +588,7 @@ module.exports = class API {
 
     deleteDB() {
 
-        return new Promise((resolve, reject) => {
+        return timeout_promise((resolve, reject) => {
 
             const msg = new database_pb.database_msg();
 
@@ -592,7 +621,7 @@ module.exports = class API {
 
     hasDB() {
 
-        return new Promise((resolve, reject) => {
+        return timeout_promise((resolve, reject) => {
 
             const msg = new database_pb.database_msg();
 
@@ -627,7 +656,7 @@ module.exports = class API {
 
     _getWriters() {
 
-        return new Promise((resolve, reject) => {
+        return timeout_promise((resolve, reject) => {
 
             const msg = new database_pb.database_msg();
 
@@ -668,7 +697,7 @@ module.exports = class API {
         assert(typeof writers === 'string' || (Array.isArray(writers) && writers.every(writer => typeof writer === 'string')),
             'Writers must be a string or an array of strings');
 
-        return new Promise((resolve, reject) => {
+        return timeout_promise((resolve, reject) => {
 
             const msg = new database_pb.database_msg();
 
@@ -706,7 +735,7 @@ module.exports = class API {
         assert(typeof writers === 'string' || (Array.isArray(writers) && writers.every(writer => typeof writer === 'string')),
             'Writers must be a string or an array of strings');
 
-        return new Promise((resolve, reject) => {
+        return timeout_promise((resolve, reject) => {
 
             const msg = new database_pb.database_msg();
 

--- a/src/test/main.test.js
+++ b/src/test/main.test.js
@@ -32,7 +32,7 @@ assert.rejects = assert.rejects || (async (p, e) => {
 
 
 const ethereum_rpc = 'http://127.0.0.1:8545';
-const contract_address = '0xBb1F6AC2Ac284650075b11A62a78d9486f176c19';
+const contract_address = '0x1C29cEB6fa40791598c06b8a293D22c8FB1445b4';
 
 
 const log = true;
@@ -437,6 +437,14 @@ describe('api', function() {
         bz2.close();
 
         assert(closed);
+
+    });
+
+
+    it('timeout', async () => {
+
+        // 1ms timeout should reject before doing anything
+        await assert.rejects(bz.create('a', 'b').timeout(1));
 
     });
 


### PR DESCRIPTION
A timeout() function is added to all Bluzelle API calls. Tests suck because I would have to mock the timeout system, which is difficult. All default commands pass through fine & a very short timeout rejects successfully.

`bluzelle.create('a', 'b') // default timeout of 5000ms`
`bluzelle.create('a', 'b').timeout(2000) // custom timeout of 2000ms`
`bluzelle.create('a', 'b').timeout(0) // indefinite; no timeout`