### PR TITLE
Default Ethereum params

### DIFF
--- a/default_connection.js
+++ b/default_connection.js
@@ -1,0 +1,4 @@
+module.exports = {
+    ethereum_rpc: 'https://ropsten.infura.io',
+    contract_address: '0x32A29AEdB45537cDFa95d1fb17377c83ae1eC0c5'
+};

--- a/scripts/run-swarms.rb
+++ b/scripts/run-swarms.rb
@@ -96,7 +96,7 @@ i = 0
       "crypto_enabled_incoming" : true,
       "monitor_address": "localhost",
       "monitor_port": 8125,
-      "ws_idle_timeout": 10000,
+      "ws_idle_timeout": 1000000,
       "swarm_id": "#{swarm_id}",
       "owner_public_key": "#{master_pub_key}"
       }))

--- a/src/main.js
+++ b/src/main.js
@@ -20,7 +20,7 @@ const abi = require('../BluzelleESR/build/contracts/BluzelleESR.json').abi;
 module.exports = {
 
     bluzelle: async ({ethereum_rpc, contract_address, _connect_to_all, log, ...args}) => {
-
+        
         ethereum_rpc = ethereum_rpc || default_connection.ethereum_rpc;
         contract_address = contract_address || default_connection.contract_address;
         

--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 const {swarmClient} = require('./swarmClient/main');
+const default_connection = require('../default_connection');
 const Web3 = require('web3');
 const abi = require('../BluzelleESR/build/contracts/BluzelleESR.json').abi;
 
@@ -20,6 +21,9 @@ module.exports = {
 
     bluzelle: async ({ethereum_rpc, contract_address, _connect_to_all, log, ...args}) => {
 
+        ethereum_rpc = ethereum_rpc || default_connection.ethereum_rpc;
+        contract_address = contract_address || default_connection.contract_address;
+        
 
         // fetch peerslist data
 

--- a/src/swarmClient/main.js
+++ b/src/swarmClient/main.js
@@ -109,10 +109,6 @@ module.exports = {
         const api = new API(sandwich.sendOutgoingMsg);
         
 
-        // These API functions aren't actual database operations
-
-        api.publicKey = () => public_pem;
-
         api.close = () => {
             connection_layer.close();
             broadcast_layer.close();

--- a/src/swarmClient/main.js
+++ b/src/swarmClient/main.js
@@ -73,8 +73,6 @@ module.exports = {
         const [ws, entry_uuid, entry_obj] = await fastest_peer(peerslist, log);
         ws.addEventListener('close', () => onclose());
 
-        debugger;
-
 
         const connection_layer = new Connection({ 
             ws,

--- a/src/test/main.test.js
+++ b/src/test/main.test.js
@@ -32,7 +32,7 @@ assert.rejects = assert.rejects || (async (p, e) => {
 
 
 const ethereum_rpc = 'http://127.0.0.1:8545';
-const contract_address = '0xa903A8b17D4707BC20Fa352CB5936cD0288759Ce';
+const contract_address = '0xb17fa3827a664Eb0CB4fF827cA320944E5E34E5D';
 
 
 const log = true;


### PR DESCRIPTION
- Ethereum rpc defaults to `https://ropsten.infura.io`
- Contract address defaults to `0x32A29AEdB45537cDFa95d1fb17377c83ae1eC0c5`
- These parameters can be individually overridden if present in the config object.
- They live in the config file `./default_connection.js` if we need to use a new contract or entry point.