### PR TITLE
Updated size() to use toObject()

### DIFF
--- a/src/swarmClient/9_api_layer.js
+++ b/src/swarmClient/9_api_layer.js
@@ -387,11 +387,7 @@ module.exports = class API {
                 assert(incoming_msg.hasSize(),
                     "A response other than size has been returned from daemon for size.");
 
-                resolve({
-                    bytes: incoming_msg.getSize().getBytes(),
-                    keys: incoming_msg.getSize().getKeys(),
-                    remainingBytes: incoming_msg.getSize().getRemainingBytes(),
-                });
+                resolve(incoming_msg.getSize().toObject());
 
                 return true;
 

--- a/src/test/.gitignore
+++ b/src/test/.gitignore
@@ -1,0 +1,1 @@
+connection_config.json

--- a/src/test/.gitignore
+++ b/src/test/.gitignore
@@ -1,1 +1,0 @@
-connection_config.json

--- a/src/test/connection_config.json
+++ b/src/test/connection_config.json
@@ -1,0 +1,4 @@
+{
+    "ethereum_rpc": "http://127.0.0.1:8545",
+    "contract_address": "0x4A63cbeD58d96397631A6Bede32beBae2030c152"
+}

--- a/src/test/main.test.js
+++ b/src/test/main.test.js
@@ -17,6 +17,8 @@ const {bluzelle, version} = require('../main');
 const assert = require('assert');
 const {random_key} = require('../swarmClient/ecdsa_secp256k1');
 
+const {ethereum_rpc, contract_address} = require('./connection_config');
+
 
 // assert.rejects polyfill (doesn't work in browser for some reason)
 assert.rejects = assert.rejects || (async (p, e) => {
@@ -30,10 +32,6 @@ assert.rejects = assert.rejects || (async (p, e) => {
     }
 
 });
-
-
-const ethereum_rpc = 'http://127.0.0.1:8545';
-const contract_address = '0x4A63cbeD58d96397631A6Bede32beBae2030c152';
 
 
 const log = true;

--- a/src/test/main.test.js
+++ b/src/test/main.test.js
@@ -33,7 +33,7 @@ assert.rejects = assert.rejects || (async (p, e) => {
 
 
 const ethereum_rpc = 'http://127.0.0.1:8545';
-const contract_address = '0x2Bc0589Fc40F21254407966B7f39654a05a7CD34';
+const contract_address = '0x4A63cbeD58d96397631A6Bede32beBae2030c152';
 
 
 const log = true;
@@ -241,6 +241,7 @@ describe('api', function() {
         assert.deepEqual(await bz.size(), {
             bytes: 0,
             keys: 0,
+            maxSize: 0,
             remainingBytes: 0
         });
 


### PR DESCRIPTION
- Adds a maxSize field to the size() output. Rest is unchanged.